### PR TITLE
fix: adjust the repo name to evmos-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,34 +39,34 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
-- [#26](https://github.com/MalteHerrmann/upgrade-local-node-go/pull/26) Enable just depositing with the binary
+- [#26](https://github.com/MalteHerrmann/evmos-utils/pull/26) Enable just depositing with the binary
 
 ### Improvements
 
-- [#27](https://github.com/MalteHerrmann/upgrade-local-node-go/pull/27) Add MIT license
-- [#28](https://github.com/MalteHerrmann/upgrade-local-node-go/pull/28) Use [Cobra CLI](https://github.com/spf13/cobra) package
+- [#27](https://github.com/MalteHerrmann/evmos-utils/pull/27) Add MIT license
+- [#28](https://github.com/MalteHerrmann/evmos-utils/pull/28) Use [Cobra CLI](https://github.com/spf13/cobra) package
 
-## [v0.3.0](https://github.com/MalteHerrmann/upgrade-local-node-go/releases/tag/v0.3.0) - 2023-08-30
+## [v0.3.0](https://github.com/MalteHerrmann/evmos-utils/releases/tag/v0.3.0) - 2023-08-30
 
 ### Features
 
-- [#14](https://github.com/MalteHerrmann/upgrade-local-node-go/pull/14) Enable just voting with the binary
+- [#14](https://github.com/MalteHerrmann/evmos-utils/pull/14) Enable just voting with the binary
 
 ### Improvements
 
-- [#7](https://github.com/MalteHerrmann/upgrade-local-node-go/pull/7) Add linters plus corresponding refactors
-- [#6](https://github.com/MalteHerrmann/upgrade-local-node-go/pull/6) Restructuring and refactoring
-- [#4](https://github.com/MalteHerrmann/upgrade-local-node-go/pull/4) Add GH actions and Makefile for testing
-- [#3](https://github.com/MalteHerrmann/upgrade-local-node-go/pull/3) Use broadcast mode `sync` instead of `block`
-- [#2](https://github.com/MalteHerrmann/upgrade-local-node-go/pull/2) Only vote if account has delegations
+- [#7](https://github.com/MalteHerrmann/evmos-utils/pull/7) Add linters plus corresponding refactors
+- [#6](https://github.com/MalteHerrmann/evmos-utils/pull/6) Restructuring and refactoring
+- [#4](https://github.com/MalteHerrmann/evmos-utils/pull/4) Add GH actions and Makefile for testing
+- [#3](https://github.com/MalteHerrmann/evmos-utils/pull/3) Use broadcast mode `sync` instead of `block`
+- [#2](https://github.com/MalteHerrmann/evmos-utils/pull/2) Only vote if account has delegations
 
-## [v0.2.0](https://github.com/MalteHerrmann/upgrade-local-node-go/releases/tag/v0.2.0) - 2023-08-09
+## [v0.2.0](https://github.com/MalteHerrmann/evmos-utils/releases/tag/v0.2.0) - 2023-08-09
 
 ### Improvements
 
-- [#1](https://github.com/MalteHerrmann/upgrade-local-node-go/pull/1) Adaptively gets keys and current proposal ID from the local node
+- [#1](https://github.com/MalteHerrmann/evmos-utils/pull/1) Adaptively gets keys and current proposal ID from the local node
 
-## [v0.1.0](https://github.com/MalteHerrmann/upgrade-local-node-go/releases/tag/v0.1.0) - 2023-08-01
+## [v0.1.0](https://github.com/MalteHerrmann/evmos-utils/releases/tag/v0.1.0) - 2023-08-01
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - [#27](https://github.com/MalteHerrmann/evmos-utils/pull/27) Add MIT license
 - [#28](https://github.com/MalteHerrmann/evmos-utils/pull/28) Use [Cobra CLI](https://github.com/spf13/cobra) package
+- [#29](https://github.com/MalteHerrmann/evmos-utils/pull/29) Adjust repository name from `upgrade-local-node-go` to `evmos-utils`
 
 ## [v0.3.0](https://github.com/MalteHerrmann/evmos-utils/releases/tag/v0.3.0) - 2023-08-30
 

--- a/README.md
+++ b/README.md
@@ -12,25 +12,26 @@ started by calling the `local_node.sh` script from the Evmos main repository.
 ## Installation
 
 In order to install the tool, clone the source and install locally.
-Note, that using `go install github.com/MalteHerrmann/upgrade-local-node-go@latest`
+
+Note, that using `go install github.com/MalteHerrmann/evmos-utils@latest`
 does not work because of the replace directives in `go.mod`,
 which are necessary for the Evmos dependencies.
 
 ```bash
-git clone https://github.com/MalteHerrmann/upgrade-local-node-go.git
-cd upgrade-local-node-go
+git clone https://github.com/MalteHerrmann/evmos-utils.git
+cd evmos-utils
 make install
 ```
 
 ## Features
 
-### Upgrade Local Node
+### Upgrade a Local Node
 
-The tool creates and submits a software upgrade proposal to a running local Evmos node,
+The tool creates and submits a software upgrade proposal to a locally running Evmos node,
 and votes on the proposal. To do so, run:
 
 ```bash
-upgrade-local-node-go [TARGET_VERSION]
+evmos-utils [TARGET_VERSION]
 ```
 
 The target version must be specified in the format `vX.Y.Z(-rc*)`, e.g. `v13.0.0-rc2`.
@@ -42,5 +43,16 @@ to validators. This can either target the most recent proposal, or a specific on
 passing an ID to the command.
 
 ```bash
-upgrade-local-node-go vote [PROPOSAL_ID]
+evmos-utils vote [PROPOSAL_ID]
 ```
+
+### Deposit for Proposal
+
+The tool can make a deposit for a proposal.
+It returns the minimum deposit necessary from the governance parameters of the running local node
+and places the deposit on behalf of the first account in the test keyring.
+
+```bash
+evmos-utils deposit [PROPOSAL_ID]
+```
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Evmos Dev Utils
+# Evmos Utils
 
 This tool contains several utility functionalities that are useful during
 development of the Evmos blockchain. 
@@ -25,13 +25,16 @@ make install
 
 ## Features
 
+The tool is based on [Cobra CLI](https://github.com/spf13/cobra) so you can use
+`--help` to get a list of all available commands and flags.
+
 ### Upgrade a Local Node
 
 The tool creates and submits a software upgrade proposal to a locally running Evmos node,
 and votes on the proposal. To do so, run:
 
 ```bash
-evmos-utils [TARGET_VERSION]
+evmos-utils upgrade [TARGET_VERSION]
 ```
 
 The target version must be specified in the format `vX.Y.Z(-rc*)`, e.g. `v13.0.0-rc2`.

--- a/cmd/deposit.go
+++ b/cmd/deposit.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"log"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/gov"
-	"github.com/MalteHerrmann/upgrade-local-node-go/utils"
+	"github.com/MalteHerrmann/evmos-utils/gov"
+	"github.com/MalteHerrmann/evmos-utils/utils"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"regexp"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/gov"
-	"github.com/MalteHerrmann/upgrade-local-node-go/utils"
+	"github.com/MalteHerrmann/evmos-utils/gov"
+	"github.com/MalteHerrmann/evmos-utils/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"log"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/gov"
-	"github.com/MalteHerrmann/upgrade-local-node-go/utils"
+	"github.com/MalteHerrmann/evmos-utils/gov"
+	"github.com/MalteHerrmann/evmos-utils/utils"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/MalteHerrmann/upgrade-local-node-go
+module github.com/MalteHerrmann/evmos-utils
 
 go 1.21
 

--- a/gov/deposit.go
+++ b/gov/deposit.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/utils"
+	"github.com/MalteHerrmann/evmos-utils/utils"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
 )

--- a/gov/deposit_test.go
+++ b/gov/deposit_test.go
@@ -3,7 +3,7 @@ package gov_test
 import (
 	"testing"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/gov"
+	"github.com/MalteHerrmann/evmos-utils/gov"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )

--- a/gov/proposal.go
+++ b/gov/proposal.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/utils"
+	"github.com/MalteHerrmann/evmos-utils/utils"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govv1types "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/pkg/errors"

--- a/gov/proposal_test.go
+++ b/gov/proposal_test.go
@@ -3,7 +3,7 @@ package gov_test
 import (
 	"testing"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/gov"
+	"github.com/MalteHerrmann/evmos-utils/gov"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )

--- a/gov/utils.go
+++ b/gov/utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/utils"
+	"github.com/MalteHerrmann/evmos-utils/utils"
 	"github.com/pkg/errors"
 )
 

--- a/gov/vote.go
+++ b/gov/vote.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/utils"
+	"github.com/MalteHerrmann/evmos-utils/utils"
 	"github.com/pkg/errors"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/MalteHerrmann/upgrade-local-node-go/cmd"
+	"github.com/MalteHerrmann/evmos-utils/cmd"
 )
 
 func main() {

--- a/utils/delegations_test.go
+++ b/utils/delegations_test.go
@@ -3,7 +3,7 @@ package utils_test
 import (
 	"testing"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/utils"
+	"github.com/MalteHerrmann/evmos-utils/utils"
 	"github.com/stretchr/testify/require"
 )
 

--- a/utils/keys_test.go
+++ b/utils/keys_test.go
@@ -3,7 +3,7 @@ package utils_test
 import (
 	"testing"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/utils"
+	"github.com/MalteHerrmann/evmos-utils/utils"
 	"github.com/stretchr/testify/require"
 )
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -3,7 +3,7 @@ package utils_test
 import (
 	"testing"
 
-	"github.com/MalteHerrmann/upgrade-local-node-go/utils"
+	"github.com/MalteHerrmann/evmos-utils/utils"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
After renaming the repository from `upgrade-local-node-go` to `evmos-utils` the necessary changes in the codebase are reflected in this PR.