### PR TITLE
imp(log): use zerolog for logging similar to SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#27](https://github.com/MalteHerrmann/evmos-utils/pull/27) Add MIT license
 - [#28](https://github.com/MalteHerrmann/evmos-utils/pull/28) Use [Cobra CLI](https://github.com/spf13/cobra) package
 - [#29](https://github.com/MalteHerrmann/evmos-utils/pull/29) Adjust repository name from `upgrade-local-node-go` to `evmos-utils`
+- [#30](https://github.com/MalteHerrmann/evmos-utils/pull/30) Use [zerolog](https://github.com/rs/zerolog) for logging
 
 ## [v0.3.0](https://github.com/MalteHerrmann/evmos-utils/releases/tag/v0.3.0) - 2023-08-30
 

--- a/cmd/deposit.go
+++ b/cmd/deposit.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/MalteHerrmann/evmos-utils/gov"
 	"github.com/MalteHerrmann/evmos-utils/utils"
 	"github.com/spf13/cobra"
@@ -10,7 +8,7 @@ import (
 
 //nolint:gochecknoglobals // required by cobra
 var depositCmd = &cobra.Command{
-	Use:   "deposit",
+	Use:   "deposit [PROPOSAL_ID]",
 	Short: "Deposit for a governance proposal",
 	Long: `Deposit the minimum needed deposit for a given governance proposal.
 If no proposal ID is given by the user, the latest proposal is queried and deposited for.`,
@@ -18,16 +16,21 @@ If no proposal ID is given by the user, the latest proposal is queried and depos
 	Run: func(cmd *cobra.Command, args []string) {
 		bin, err := utils.NewEvmosTestingBinary()
 		if err != nil {
-			log.Fatalf("error creating binary: %v", err)
+			bin.Logger.Error().Msgf("error creating binary: %v", err)
+			return
 		}
 
 		if err = bin.GetAccounts(); err != nil {
-			log.Fatalf("error getting accounts: %v", err)
+			bin.Logger.Error().Msgf("error getting accounts: %v", err)
+			return
 		}
 
-		err = gov.Deposit(bin, args)
+		proposalID, err := gov.Deposit(bin, args)
 		if err != nil {
-			log.Fatalf("error depositing: %v", err)
+			bin.Logger.Error().Msgf("error depositing: %v", err)
+			return
+		} else {
+			bin.Logger.Info().Msgf("successfully deposited for proposal %d", proposalID)
 		}
 	},
 }

--- a/cmd/deposit.go
+++ b/cmd/deposit.go
@@ -17,17 +17,20 @@ If no proposal ID is given by the user, the latest proposal is queried and depos
 		bin, err := utils.NewEvmosTestingBinary()
 		if err != nil {
 			bin.Logger.Error().Msgf("error creating binary: %v", err)
+
 			return
 		}
 
 		if err = bin.GetAccounts(); err != nil {
 			bin.Logger.Error().Msgf("error getting accounts: %v", err)
+
 			return
 		}
 
 		proposalID, err := gov.Deposit(bin, args)
 		if err != nil {
 			bin.Logger.Error().Msgf("error depositing: %v", err)
+
 			return
 		}
 

--- a/cmd/deposit.go
+++ b/cmd/deposit.go
@@ -29,9 +29,9 @@ If no proposal ID is given by the user, the latest proposal is queried and depos
 		if err != nil {
 			bin.Logger.Error().Msgf("error depositing: %v", err)
 			return
-		} else {
-			bin.Logger.Info().Msgf("successfully deposited for proposal %d", proposalID)
 		}
+
+		bin.Logger.Info().Msgf("successfully deposited for proposal %d", proposalID)
 	},
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -20,22 +20,26 @@ voting for it using all keys of in the keyring and having it pass.`,
 		bin, err := utils.NewEvmosTestingBinary()
 		if err != nil {
 			bin.Logger.Error().Msgf("error creating binary: %v", err)
+
 			return
 		}
 
 		if err = bin.GetAccounts(); err != nil {
 			bin.Logger.Error().Msgf("error getting accounts: %v", err)
+
 			return
 		}
 
 		targetVersion := args[0]
 		if matched, _ := regexp.MatchString(`v\d+\.\d+\.\d(-rc\d+)?`, targetVersion); !matched {
 			bin.Logger.Error().Msgf("invalid target version: %s; please use the format vX.Y.Z(-rc*).", targetVersion)
+
 			return
 		}
 
 		if err := upgradeLocalNode(bin, targetVersion); err != nil {
 			bin.Logger.Error().Msgf("error upgrading local node: %v", err)
+
 			return
 		}
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -37,9 +37,9 @@ voting for it using all keys of in the keyring and having it pass.`,
 		if err := upgradeLocalNode(bin, targetVersion); err != nil {
 			bin.Logger.Error().Msgf("error upgrading local node: %v", err)
 			return
-		} else {
-			bin.Logger.Info().Msgf("successfully prepared upgrade to %s", targetVersion)
 		}
+
+		bin.Logger.Info().Msgf("successfully prepared upgrade to %s", targetVersion)
 	},
 }
 
@@ -58,14 +58,14 @@ func upgradeLocalNode(bin *utils.Binary, targetVersion string) error {
 
 	upgradeHeight := currentHeight + utils.DeltaHeight
 
-	bin.Logger.Error().Msg("Submitting upgrade proposal...")
+	bin.Logger.Error().Msg("submitting upgrade proposal...")
 
 	proposalID, err := gov.SubmitUpgradeProposal(bin, targetVersion, upgradeHeight)
 	if err != nil {
 		return errors.Wrap(err, "error executing upgrade proposal")
 	}
 
-	bin.Logger.Info().Msgf("Scheduled upgrade to %s at height %d.\n", targetVersion, upgradeHeight)
+	bin.Logger.Info().Msgf("scheduled upgrade to %s at height %d.\n", targetVersion, upgradeHeight)
 
 	if err = gov.SubmitAllVotesForProposal(bin, proposalID); err != nil {
 		return errors.Wrapf(err, "error submitting votes for proposal %d", proposalID)

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -17,17 +17,20 @@ If no proposal ID is passed, the latest proposal on chain is queried and used.`,
 		bin, err := utils.NewEvmosTestingBinary()
 		if err != nil {
 			bin.Logger.Error().Msgf("error creating binary: %v", err)
+
 			return
 		}
 
 		if err = bin.GetAccounts(); err != nil {
 			bin.Logger.Error().Msgf("error getting accounts: %v", err)
+
 			return
 		}
 
 		proposalID, err := gov.SubmitAllVotes(bin, args)
 		if err != nil {
 			bin.Logger.Error().Msgf("error submitting votes: %v", err)
+
 			return
 		}
 

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/MalteHerrmann/evmos-utils/gov"
 	"github.com/MalteHerrmann/evmos-utils/utils"
 	"github.com/spf13/cobra"
@@ -10,7 +8,7 @@ import (
 
 //nolint:gochecknoglobals // required by cobra
 var voteCmd = &cobra.Command{
-	Use:   "vote",
+	Use:   "vote [PROPOSAL_ID]",
 	Short: "Vote for a governance proposal",
 	Long: `Vote for a governance proposal with all keys in the keyring.
 If no proposal ID is passed, the latest proposal on chain is queried and used.`,
@@ -18,15 +16,21 @@ If no proposal ID is passed, the latest proposal on chain is queried and used.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		bin, err := utils.NewEvmosTestingBinary()
 		if err != nil {
-			log.Fatalf("error creating binary: %v", err)
+			bin.Logger.Error().Msgf("error creating binary: %v", err)
+			return
 		}
 
 		if err = bin.GetAccounts(); err != nil {
-			log.Fatalf("error getting accounts: %v", err)
+			bin.Logger.Error().Msgf("error getting accounts: %v", err)
+			return
 		}
 
-		if err = gov.SubmitAllVotes(bin, args); err != nil {
-			log.Fatal(err)
+		proposalID, err := gov.SubmitAllVotes(bin, args)
+		if err != nil {
+			bin.Logger.Error().Msgf("error submitting votes: %v", err)
+			return
+		} else {
+			bin.Logger.Info().Msgf("successfully submitted votes for proposal %d", proposalID)
 		}
 	},
 }

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -29,9 +29,9 @@ If no proposal ID is passed, the latest proposal on chain is queried and used.`,
 		if err != nil {
 			bin.Logger.Error().Msgf("error submitting votes: %v", err)
 			return
-		} else {
-			bin.Logger.Info().Msgf("successfully submitted votes for proposal %d", proposalID)
 		}
+
+		bin.Logger.Info().Msgf("successfully submitted votes for proposal %d", proposalID)
 	},
 }
 

--- a/gov/deposit.go
+++ b/gov/deposit.go
@@ -2,7 +2,6 @@ package gov
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"strconv"
 
@@ -12,18 +11,18 @@ import (
 )
 
 // Deposit deposits the minimum needed deposit for a given governance proposal.
-func Deposit(bin *utils.Binary, args []string) error {
+func Deposit(bin *utils.Binary, args []string) (int, error) {
 	deposit, err := GetMinDeposit(bin)
 	if err != nil {
-		log.Fatalf("error getting minimum deposit: %v", err)
+		return 0, errors.Wrap(err, "failed to get minimum deposit")
 	}
 
 	proposalID, err := GetProposalIDFromInput(bin, args)
 	if err != nil {
-		log.Fatalf("error getting proposal ID: %v", err)
+		return 0, errors.Wrap(err, "failed to get proposal ID")
 	}
 
-	return DepositForProposal(
+	return proposalID, DepositForProposal(
 		bin, proposalID, bin.Accounts[0].Name, deposit.String(),
 	)
 }

--- a/gov/utils.go
+++ b/gov/utils.go
@@ -22,9 +22,9 @@ func GetProposalIDFromInput(bin *utils.Binary, args []string) (int, error) {
 			return 0, errors.Wrap(err, "error querying latest proposal ID")
 		}
 	case 1:
-		proposalID, err = strconv.Atoi(args[2])
+		proposalID, err = strconv.Atoi(args[0])
 		if err != nil {
-			return 0, errors.Wrapf(err, "error converting proposal ID %s to integer", args[2])
+			return 0, errors.Wrapf(err, "error converting proposal ID %s to integer", args[0])
 		}
 	default:
 		return 0, fmt.Errorf("invalid number of arguments; expected 0 or 1; got %d", len(args))

--- a/gov/vote.go
+++ b/gov/vote.go
@@ -2,7 +2,6 @@ package gov
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
@@ -11,13 +10,13 @@ import (
 )
 
 // SubmitAllVotes submits a vote for the given proposal ID using all testing accounts.
-func SubmitAllVotes(bin *utils.Binary, args []string) error {
+func SubmitAllVotes(bin *utils.Binary, args []string) (int, error) {
 	proposalID, err := GetProposalIDFromInput(bin, args)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	return SubmitAllVotesForProposal(bin, proposalID)
+	return proposalID, SubmitAllVotesForProposal(bin, proposalID)
 }
 
 // SubmitAllVotesForProposal submits a vote for the given proposal ID using all testing accounts.
@@ -32,7 +31,7 @@ func SubmitAllVotesForProposal(bin *utils.Binary, proposalID int) error {
 	}
 
 	utils.Wait(1)
-	log.Printf("Voting for proposal %d...\n", proposalID)
+	bin.Logger.Info().Msgf("Voting for proposal %d", proposalID)
 
 	var out string
 
@@ -47,9 +46,9 @@ func SubmitAllVotesForProposal(bin *utils.Binary, proposalID int) error {
 				return fmt.Errorf("proposal with ID %d is inactive", proposalID)
 			}
 
-			log.Printf("  - could NOT vote using key: %s\n", acc.Name)
+			bin.Logger.Error().Msgf("could not vote using key %s: %v", acc.Name, err)
 		} else {
-			log.Printf("  - voted using key: %s\n", acc.Name)
+			bin.Logger.Info().Msgf("voted using key %s", acc.Name)
 		}
 	}
 

--- a/gov/vote.go
+++ b/gov/vote.go
@@ -31,7 +31,7 @@ func SubmitAllVotesForProposal(bin *utils.Binary, proposalID int) error {
 	}
 
 	utils.Wait(1)
-	bin.Logger.Info().Msgf("Voting for proposal %d", proposalID)
+	bin.Logger.Info().Msgf("voting for proposal %d", proposalID)
 
 	var out string
 

--- a/utils/binary.go
+++ b/utils/binary.go
@@ -2,8 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"os"
 	"os/exec"
 	"path"
@@ -12,6 +10,8 @@ import (
 	"github.com/evmos/evmos/v14/app"
 	"github.com/evmos/evmos/v14/encoding"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 // Binary is a struct to hold the necessary information to execute commands

--- a/utils/binary.go
+++ b/utils/binary.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"os"
 	"os/exec"
 	"path"
@@ -23,10 +25,12 @@ type Binary struct {
 	Appd string
 	// Accounts are the accounts stored in the local keyring.
 	Accounts []Account
+	// Logger is a logger to be used within all commands.
+	Logger zerolog.Logger
 }
 
 // NewBinary returns a new Binary instance.
-func NewBinary(home, appd string) (*Binary, error) {
+func NewBinary(home, appd string, logger zerolog.Logger) (*Binary, error) {
 	// check if home directory exists
 	if _, err := os.Stat(home); os.IsNotExist(err) {
 		return nil, errors.Wrap(err, fmt.Sprintf("home directory does not exist: %s", home))
@@ -44,23 +48,26 @@ func NewBinary(home, appd string) (*Binary, error) {
 	}
 
 	return &Binary{
-		Cdc:  cdc,
-		Home: home,
-		Appd: appd,
+		Cdc:    cdc,
+		Home:   home,
+		Appd:   appd,
+		Logger: logger,
 	}, nil
 }
 
 // NewEvmosTestingBinary returns a new Binary instance with the default home and appd
 // setup for the Evmos local node testing setup.
 func NewEvmosTestingBinary() (*Binary, error) {
+	logger := log.Output(zerolog.ConsoleWriter{Out: os.Stdout})
+
 	userHome, err := os.UserHomeDir()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get user home dir")
+		return &Binary{Logger: logger}, errors.Wrap(err, "failed to get user home dir")
 	}
 
 	defaultEvmosdHome := path.Join(userHome, ".tmp-evmosd")
 
-	return NewBinary(defaultEvmosdHome, "evmosd")
+	return NewBinary(defaultEvmosdHome, "evmosd", logger)
 }
 
 // GetCodec returns the codec to be used for the client.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -46,7 +45,7 @@ func ExecuteBinaryCmd(bin *Binary, args BinaryCmdArgs) (string, error) {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil && !args.Quiet {
-		log.Println(string(output))
+		bin.Logger.Error().Msg(string(output))
 	}
 
 	return string(output), err


### PR DESCRIPTION
This PR switches from using the standard log package to using the `zerolog` package for prettified console logging as it is used in CometBFT or the Cosmos SDK.