### PR TITLE
imp(cli): Add flags to CLI commands to enable more configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,8 @@ linters:
     # discontinued linters
     - deadcode
     - exhaustivestruct
+    - gochecknoglobals
+    - gochecknoinits
     - golint
     - ifshort
     - interfacer

--- a/cmd/deposit.go
+++ b/cmd/deposit.go
@@ -14,7 +14,7 @@ var depositCmd = &cobra.Command{
 If no proposal ID is given by the user, the latest proposal is queried and deposited for.`,
 	Args: cobra.RangeArgs(0, 1),
 	Run: func(_ *cobra.Command, args []string) {
-		bin, err := utils.NewEvmosTestingBinary()
+		bin, err := utils.NewBinary(collectConfig())
 		if err != nil {
 			bin.Logger.Error().Msgf("error creating binary: %v", err)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,24 +3,91 @@ package cmd
 import (
 	"os"
 
+	"github.com/MalteHerrmann/evmos-utils/utils"
+	evmosutils "github.com/evmos/evmos/v17/utils"
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands.
-//
-//nolint:gochecknoglobals // required by cobra
-var rootCmd = &cobra.Command{
-	Use:   "evmos-utils",
-	Short: "A collection of utilities to interact with an Evmos node during development.",
-	Long: `The evmos-utils collection offers helpers to interact with an Evmos node during development.
+var (
+	// rootCmd represents the base command when called without any subcommands.
+	//
+	//nolint:gochecknoglobals // required by cobra
+	rootCmd = &cobra.Command{
+		Use:   "evmos-utils",
+		Short: "A collection of utilities to interact with an Evmos node during development.",
+		Long: `The evmos-utils collection offers helpers to interact with an Evmos node during development.
 It can be used to test upgrades, deposit or vote for specific or the latest proposals, etc.`,
-}
+	}
+
+	// appd is the name of the binary to execute commands with.
+	appd string
+	// chainID is the chain ID of the network.
+	chainID string
+	// denom of the chain's fee token.
+	denom string
+	// home is the home directory of the binary.
+	home string
+	// keyringBackend is the keyring to use.
+	keyringBackend string
+	// node to post requests and transactions to.
+	node string
+)
 
 //nolint:gochecknoinits // required by cobra
 func init() {
-	rootCmd.AddCommand(depositCmd)
+	rootCmd.PersistentFlags().StringVar(
+		&appd,
+		"bin",
+		"evmosd",
+		"Name of the binary to be executed",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&chainID,
+		"chain-id",
+		evmosutils.TestnetChainID+"-1",
+		"Chain ID of the network",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&denom,
+		"denom",
+		"aevmos",
+		"Fee token denomination of the network",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&home,
+		"home",
+		".tmp-evmosd",
+		"Home directory of the binary",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&keyringBackend,
+		"keyring-backend",
+		"test",
+		"Keyring to use",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&node,
+		"node",
+		"http://localhost:26657",
+		"Node to post queries and transactions to",
+	)
+
 	rootCmd.AddCommand(upgradeCmd)
+	rootCmd.AddCommand(depositCmd)
 	rootCmd.AddCommand(voteCmd)
+}
+
+// collectConfig returns a BinaryConfig filled with the current configuration options
+// that depend on the passed flags to the given CLI commands.
+func collectConfig() utils.BinaryConfig {
+	return utils.BinaryConfig{
+		Appd:           appd,
+		ChainID:        chainID,
+		Denom:          denom,
+		Home:           home,
+		KeyringBackend: keyringBackend,
+		Node:           node,
+	}
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -14,7 +14,7 @@ var voteCmd = &cobra.Command{
 If no proposal ID is passed, the latest proposal on chain is queried and used.`,
 	Args: cobra.RangeArgs(0, 1),
 	Run: func(_ *cobra.Command, args []string) {
-		bin, err := utils.NewEvmosTestingBinary()
+		bin, err := utils.NewBinary(collectConfig())
 		if err != nil {
 			bin.Logger.Error().Msgf("error creating binary: %v", err)
 

--- a/gov/deposit.go
+++ b/gov/deposit.go
@@ -30,13 +30,12 @@ func Deposit(bin *utils.Binary, args []string) (int, error) {
 // DepositForProposal deposits the given amount for the proposal with the given proposalID
 // from the given account.
 func DepositForProposal(bin *utils.Binary, proposalID int, sender, deposit string) error {
-	_, err := utils.ExecuteBinaryCmd(bin, utils.BinaryCmdArgs{
+	_, err := utils.ExecuteTx(bin, utils.TxArgs{
 		Subcommand: []string{
 			"tx", "gov", "deposit", strconv.Itoa(proposalID), deposit,
 		},
-		From:        sender,
-		UseDefaults: true,
-		Quiet:       true,
+		From:  sender,
+		Quiet: true,
 	})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to deposit for proposal %d", proposalID))
@@ -48,7 +47,7 @@ func DepositForProposal(bin *utils.Binary, proposalID int, sender, deposit strin
 // GetMinDeposit returns the minimum deposit necessary for a proposal from the governance parameters of
 // the running chain.
 func GetMinDeposit(bin *utils.Binary) (sdk.Coins, error) {
-	out, err := utils.ExecuteBinaryCmd(bin, utils.BinaryCmdArgs{
+	out, err := utils.ExecuteQuery(bin, utils.QueryArgs{
 		Subcommand: []string{"q", "gov", "param", "deposit", "--output=json"},
 		Quiet:      true,
 	})

--- a/gov/proposal.go
+++ b/gov/proposal.go
@@ -12,13 +12,13 @@ import (
 )
 
 // buildUpgradeProposalCommand builds the command to submit a software upgrade proposal.
-func buildUpgradeProposalCommand(targetVersion string, upgradeHeight int) []string {
+func buildUpgradeProposalCommand(targetVersion string, upgradeHeight int, denom string) []string {
 	return []string{
 		"tx", "gov", "submit-legacy-proposal", "software-upgrade", targetVersion,
 		"--title", fmt.Sprintf("'Upgrade to %s'", targetVersion),
 		"--description", fmt.Sprintf("'Upgrade to %s'", targetVersion),
 		"--upgrade-height", strconv.Itoa(upgradeHeight),
-		"--deposit", "100000000000000000000aevmos",
+		"--deposit", "100000000000000000000" + denom,
 		"--output", "json",
 		"--no-validate",
 	}
@@ -49,7 +49,7 @@ func GetProposalIDFromSubmitEvents(events []sdk.StringEvent) (int, error) {
 
 // QueryLatestProposalID queries the latest proposal ID.
 func QueryLatestProposalID(bin *utils.Binary) (int, error) {
-	out, err := utils.ExecuteBinaryCmd(bin, utils.BinaryCmdArgs{
+	out, err := utils.ExecuteQuery(bin, utils.QueryArgs{
 		Subcommand: []string{"q", "gov", "proposals", "--output=json"},
 		Quiet:      true,
 	})
@@ -79,12 +79,11 @@ func QueryLatestProposalID(bin *utils.Binary) (int, error) {
 
 // SubmitUpgradeProposal submits a software upgrade proposal with the given target version and upgrade height.
 func SubmitUpgradeProposal(bin *utils.Binary, targetVersion string, upgradeHeight int) (int, error) {
-	upgradeProposal := buildUpgradeProposalCommand(targetVersion, upgradeHeight)
+	upgradeProposal := buildUpgradeProposalCommand(targetVersion, upgradeHeight, bin.Config.Denom)
 
-	out, err := utils.ExecuteBinaryCmd(bin, utils.BinaryCmdArgs{
-		Subcommand:  upgradeProposal,
-		From:        "dev0",
-		UseDefaults: true,
+	out, err := utils.ExecuteTx(bin, utils.TxArgs{
+		Subcommand: upgradeProposal,
+		From:       "dev0",
 	})
 	if err != nil {
 		return 0, errors.Wrap(err,

--- a/gov/vote.go
+++ b/gov/vote.go
@@ -57,11 +57,10 @@ func SubmitAllVotesForProposal(bin *utils.Binary, proposalID int) error {
 
 // VoteForProposal votes for the proposal with the given ID using the given account.
 func VoteForProposal(bin *utils.Binary, proposalID int, sender string) (string, error) {
-	out, err := utils.ExecuteBinaryCmd(bin, utils.BinaryCmdArgs{
-		Subcommand:  []string{"tx", "gov", "vote", strconv.Itoa(proposalID), "yes"},
-		From:        sender,
-		UseDefaults: true,
-		Quiet:       true,
+	out, err := utils.ExecuteTx(bin, utils.TxArgs{
+		Subcommand: []string{"tx", "gov", "vote", strconv.Itoa(proposalID), "yes"},
+		From:       sender,
+		Quiet:      true,
 	})
 	if err != nil {
 		return out, errors.Wrap(err, fmt.Sprintf("failed to vote for proposal %d", proposalID))

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -1,14 +1,8 @@
 package utils
 
-import (
-	evmosutils "github.com/evmos/evmos/v17/utils"
-)
-
 const (
 	// defaultFees is the amount of fees to be sent with a default transaction.
-	defaultFees int = 1e18 // 1 aevmos
+	defaultFees int = 1e16 // 0.01 evmos
 	// DeltaHeight is the amount of blocks in the future that the upgrade will be scheduled.
 	DeltaHeight = 20
-	// denom is the denomination used for the local node.
-	denom = evmosutils.BaseDenom
 )

--- a/utils/keys.go
+++ b/utils/keys.go
@@ -18,11 +18,11 @@ type Account struct {
 	Delegations []stakingtypes.Delegation `json:"delegations"`
 }
 
-// GetAccounts is a method to retrieve the binaries keys from the configured
+// getAccounts is a method to retrieve the binaries keys from the configured
 // keyring backend and stores it in the Binary struct.
-func (bin *Binary) GetAccounts() error {
+func (bin *Binary) getAccounts() error {
 	out, err := ExecuteBinaryCmd(bin, BinaryCmdArgs{
-		Subcommand: []string{"keys", "list", "--output=json"},
+		Subcommand: []string{"keys", "list", "--output=json", "--home", bin.Config.Home},
 	})
 	if err != nil {
 		return err
@@ -47,7 +47,7 @@ func FilterAccountsWithDelegations(bin *Binary) ([]Account, error) {
 	}
 
 	for _, acc := range bin.Accounts {
-		out, err := ExecuteBinaryCmd(bin, BinaryCmdArgs{
+		out, err := ExecuteQuery(bin, QueryArgs{
 			Subcommand: []string{"query", "staking", "delegations", acc.Address, "--output=json"},
 		})
 		if err != nil {


### PR DESCRIPTION
In order to make the tool more applicable for different use cases, this PR adds the use of flags to the CLI which enable adjusting the commands and use a different chain binary.